### PR TITLE
device.cancelConnection() bug fix

### DIFF
--- a/src/Device.js
+++ b/src/Device.js
@@ -12,7 +12,7 @@ export default class Device {
         }
 
         this.cancelConnection = () => {
-            return manager.cancelDeviceConnection(this.uuid, options)
+            return manager.cancelDeviceConnection(this.uuid)
         }
 
         this.isConnected = () => {


### PR DESCRIPTION
Remove second argument (options) which appears to be unnecessary and
generates a runtime error .