### PR TITLE
Try to destroy BLE client as cleanly as possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Example apps are available in [Google Play](https://play.google.com/store/apps/d
   * Input Files:
     * `$(SRCROOT)/../node_modules/react-native-ble-plx/ios/BleClientManager/Carthage/Build/iOS/BleClientManager.framework`
     * `$(SRCROOT)/../node_modules/react-native-ble-plx/ios/BleClientManager/Carthage/Build/iOS/RxSwift.framework`
-    * `$(SRCROOT)/../node_modules/react-native-ble-plx/ios/BleClientManager/Carthage/Build/iOS/RxCocoa.framework`
     * `$(SRCROOT)/../node_modules/react-native-ble-plx/ios/BleClientManager/Carthage/Build/iOS/RxBluetoothKit.framework`
 * Minimal supported version of iOS is 8.0
 

--- a/ios/BleClient.m
+++ b/ios/BleClient.m
@@ -41,6 +41,7 @@ RCT_EXPORT_METHOD(createClient) {
 }
 
 RCT_EXPORT_METHOD(destroyClient) {
+    [_manager invalidate];
     _manager = nil;
 }
 

--- a/ios/BleClient.xcodeproj/project.pbxproj
+++ b/ios/BleClient.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		D7970CE81D4F8E5D00231A1B /* BleClientManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7970CE41D4F8E5D00231A1B /* BleClientManager.framework */; };
 		D7970CE91D4F8E5D00231A1B /* RxBluetoothKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7970CE51D4F8E5D00231A1B /* RxBluetoothKit.framework */; };
 		D7970CEA1D4F8E5D00231A1B /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7970CE61D4F8E5D00231A1B /* RxSwift.framework */; };
-		D7970CEB1D4F8E5D00231A1B /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7970CE71D4F8E5D00231A1B /* RxCocoa.framework */; };
 		D7D202791D4F614D00E10F6A /* BleClient.m in Sources */ = {isa = PBXBuildFile; fileRef = D7D202771D4F614D00E10F6A /* BleClient.m */; };
 /* End PBXBuildFile section */
 
@@ -31,7 +30,6 @@
 		D7970CE41D4F8E5D00231A1B /* BleClientManager.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BleClientManager.framework; path = BleClientManager/Carthage/Build/iOS/BleClientManager.framework; sourceTree = "<group>"; };
 		D7970CE51D4F8E5D00231A1B /* RxBluetoothKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxBluetoothKit.framework; path = BleClientManager/Carthage/Build/iOS/RxBluetoothKit.framework; sourceTree = "<group>"; };
 		D7970CE61D4F8E5D00231A1B /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = BleClientManager/Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
-		D7970CE71D4F8E5D00231A1B /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = BleClientManager/Carthage/Build/iOS/RxCocoa.framework; sourceTree = "<group>"; };
 		D7D202771D4F614D00E10F6A /* BleClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BleClient.m; sourceTree = "<group>"; };
 		D7D202781D4F614D00E10F6A /* BleClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BleClient.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -44,7 +42,6 @@
 				D7970CE81D4F8E5D00231A1B /* BleClientManager.framework in Frameworks */,
 				D7970CE91D4F8E5D00231A1B /* RxBluetoothKit.framework in Frameworks */,
 				D7970CEA1D4F8E5D00231A1B /* RxSwift.framework in Frameworks */,
-				D7970CEB1D4F8E5D00231A1B /* RxCocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -57,7 +54,6 @@
 				D7970CE41D4F8E5D00231A1B /* BleClientManager.framework */,
 				D7970CE51D4F8E5D00231A1B /* RxBluetoothKit.framework */,
 				D7970CE61D4F8E5D00231A1B /* RxSwift.framework */,
-				D7970CE71D4F8E5D00231A1B /* RxCocoa.framework */,
 				D7D202771D4F614D00E10F6A /* BleClient.m */,
 				D7D202781D4F614D00E10F6A /* BleClient.h */,
 				D73F06E91D48E17B00AD5963 /* Products */,

--- a/ios/BleClientManager/BleClientManager.xcodeproj/project.pbxproj
+++ b/ios/BleClientManager/BleClientManager.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		D735382D1DBF96BD0052F6B5 /* SafePromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = D735382C1DBF96BD0052F6B5 /* SafePromise.swift */; };
 		D77BF8461D54B46D00CDEA1D /* BleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77BF8451D54B46D00CDEA1D /* BleExtensions.swift */; };
 		D7970CC61D4F864B00231A1B /* RxBluetoothKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7970CC31D4F864B00231A1B /* RxBluetoothKit.framework */; };
-		D7970CC71D4F864B00231A1B /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7970CC41D4F864B00231A1B /* RxCocoa.framework */; };
 		D7970CC81D4F864B00231A1B /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7970CC51D4F864B00231A1B /* RxSwift.framework */; };
 		D7D202801D4F617C00E10F6A /* BleModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D2027A1D4F617C00E10F6A /* BleModule.swift */; };
 		D7D202811D4F617C00E10F6A /* BleEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D2027B1D4F617C00E10F6A /* BleEvent.swift */; };
@@ -29,7 +28,6 @@
 		D73F07A11D49033A00AD5963 /* BleClientManager.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BleClientManager.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D77BF8451D54B46D00CDEA1D /* BleExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BleExtensions.swift; sourceTree = "<group>"; };
 		D7970CC31D4F864B00231A1B /* RxBluetoothKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxBluetoothKit.framework; path = Carthage/Build/iOS/RxBluetoothKit.framework; sourceTree = "<group>"; };
-		D7970CC41D4F864B00231A1B /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/iOS/RxCocoa.framework; sourceTree = "<group>"; };
 		D7970CC51D4F864B00231A1B /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
 		D7D2027A1D4F617C00E10F6A /* BleModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BleModule.swift; sourceTree = "<group>"; };
 		D7D2027B1D4F617C00E10F6A /* BleEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BleEvent.swift; sourceTree = "<group>"; };
@@ -45,7 +43,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D7970CC61D4F864B00231A1B /* RxBluetoothKit.framework in Frameworks */,
-				D7970CC71D4F864B00231A1B /* RxCocoa.framework in Frameworks */,
 				D7970CC81D4F864B00231A1B /* RxSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -67,7 +64,6 @@
 			isa = PBXGroup;
 			children = (
 				D7970CC31D4F864B00231A1B /* RxBluetoothKit.framework */,
-				D7970CC41D4F864B00231A1B /* RxCocoa.framework */,
 				D7970CC51D4F864B00231A1B /* RxSwift.framework */,
 				D7D2027A1D4F617C00E10F6A /* BleModule.swift */,
 				D7D2027B1D4F617C00E10F6A /* BleEvent.swift */,

--- a/ios/BleClientManager/BleModule.swift
+++ b/ios/BleClientManager/BleModule.swift
@@ -43,6 +43,17 @@ public class BleClientManager : NSObject {
         })
     }
 
+    public func invalidate() {
+        scanSubscription.disposable = NopDisposable.instance
+        transactions.dispose()
+        connectingDevices.dispose()
+        connectedDevices.forEach { (_, device) in
+            _ = device.cancelConnection().subscribe()
+        }
+        connectedDevices.removeAll()
+        monitoredCharacteristics.removeAll()
+    }
+
     deinit {
         scanSubscription.disposable = NopDisposable.instance
     }

--- a/ios/BleClientManager/Utils/DisposableMap.swift
+++ b/ios/BleClientManager/Utils/DisposableMap.swift
@@ -20,10 +20,15 @@ class DisposableMap<T: Hashable> {
         replaceDisposable(key, disposable: nil)
     }
 
-    deinit {
+    func dispose() {
         disposables.forEach {
             (_, disposable) in
             disposable.dispose()
         }
+        disposables.removeAll()
+    }
+
+    deinit {
+        dispose()
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ble-plx",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "React Native Bluetooth Low Energy library",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Running dispose() from Dispoables in deinit function of Manager's class doesn't allow to cleanly close all pending connection to devices. Instead call invalidate when BleClient is about to be destroyed.

Additionaly remove RxCocoa dependency from module, as it's not necessary.