### PR TITLE
deps - upgrade react-native to 0.44.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jest": "^20.0.3",
     "prettier": "^1.3.1",
     "react": "16.0.0-alpha.6",
-    "react-native": "0.44.0"
+    "react-native": "0.44.2"
   },
   "keywords": [
     "React",


### PR DESCRIPTION
The pinned react-native version is causing issues with anyone wanting 0.44.2.

While the ideal situation would be to have the dependency as ^0.44.0, I understand there is some cases where pinned the dependency helps with stability.

Let me know if instead you would like to have it as above, if there wasn't a reason.