### PR TITLE
Use generic react native version to avoid duplicates

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:0.20.1"
+    compile "com.facebook.react:react-native:+"
     compile "com.polidea.rxandroidble:rxandroidble:1.3.3"
 
     testCompile 'org.robospock:robospock:1.0.1'


### PR DESCRIPTION
Same story as [here](https://github.com/tinycreative/react-native-intercom/pull/94). Using multiple versions makes a mess.