### PR TITLE
Improve library setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Documentation can be found [here](https://polidea.github.io/react-native-ble-plx
 
 ## Configuration & Installation
 
+### Important
+If you do not have [Carthage](https://github.com/Carthage/Carthage) installed yet and 
+wish to set up for iOS, please install it first and only then follow the steps given below
+
 ### Automatically
 
 ```bash


### PR DESCRIPTION
Ran into the **"Module BleClient Manager not found"** issue while integrating this library for iOS. While I was able to figure out the issue, I actually had to spend a good part of a day trying to figure out why it just wouldn't built for iOS. 

The reason I got this build error was because I didn't have **Carthage** installed, and thus the library wasn't set up right. While trying to setup this library, I went the automatic route, so I did a `react-native link` and then followed the manual steps starting from step 7 skipping steps 1-6.  I see step 2 has the instruction to install **Carthage** but that didn't seem to be a required step to do going by the instructions in the README

I was able to get it working only after getting **Carthage** installed first, and then following the steps available in the README

I've made some minor addition to the instruction available in the README

PS: Thanks for this library