### PR TITLE
Remove createJSModules @override - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/polidea/reactnativeble/BlePackage.java
+++ b/android/src/main/java/com/polidea/reactnativeble/BlePackage.java
@@ -12,11 +12,6 @@ import java.util.List;
 public class BlePackage implements ReactPackage {
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/polidea/reactnativeble/BlePackage.java
+++ b/android/src/main/java/com/polidea/reactnativeble/BlePackage.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public class BlePackage implements ReactPackage {
 
-    // Deprecated RN 0.47
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/polidea/reactnativeble/BlePackage.java
+++ b/android/src/main/java/com/polidea/reactnativeble/BlePackage.java
@@ -10,6 +10,10 @@ import java.util.Collections;
 import java.util.List;
 
 public class BlePackage implements ReactPackage {
+    
+    public List<Class<? extends JavaScriptModule>> createJSModules() {		
+        return Collections.emptyList();		
+    }
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {

--- a/android/src/main/java/com/polidea/reactnativeble/BlePackage.java
+++ b/android/src/main/java/com/polidea/reactnativeble/BlePackage.java
@@ -10,9 +10,10 @@ import java.util.Collections;
 import java.util.List;
 
 public class BlePackage implements ReactPackage {
-    
-    public List<Class<? extends JavaScriptModule>> createJSModules() {		
-        return Collections.emptyList();		
+
+    // Deprecated RN 0.47
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
     }
 
     @Override


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method/override marker. This is backwards compatible according to my tests.