### PR TITLE
How to fix proguard warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,13 @@ android {
         android:minSdkVersion="18"
         ...
 ```
+
+## Troubleshooting
+
+### Problems with Proguard
+
+Add this to your `app/proguard-rules.pro`
+
+```
+-dontwarn com.polidea.reactnativeble.**
+```


### PR DESCRIPTION
When proguard is enabled, you will get this two warnings:

```
Warning: com.polidea.reactnativeble.BleModule: can't find referenced class com.polidea.reactnativeble.utils.Constants$BluetoothState
Warning: com.polidea.reactnativeble.utils.LogLevel: can't find referenced class com.polidea.reactnativeble.utils.Constants$BluetoothLogLevel
```

