### PR TITLE
Fail explicitly when carthage fails on postinstall

### DIFF
--- a/build_ios_frameworks.sh
+++ b/build_ios_frameworks.sh
@@ -2,7 +2,7 @@
 
 command -v carthage >/dev/null 2>&1 || { 
   echo >&2 "Warning: Carthage is required to compile frameworks for iOS backend. You can install it with brew: brew install carthage. After installation go to ./node_modules/react-native-ble-plx and run ./build_ios_frameworks.sh or reinstall node module."
-  exit 0 
+  exit 1
 }
 
 cd ./ios/BleClientManager

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,8 +1,10 @@
 var childProcess = require('child_process');
 
 if (process.platform === 'darwin') {
-  childProcess.spawn('./build_ios_frameworks.sh', [], {
+  var result = childProcess.spawnSync('./build_ios_frameworks.sh', [], {
     shell: 'bash',
     stdio: 'inherit',
   });
+
+  process.exit(result.status);
 }


### PR DESCRIPTION
Lack or wrong version of carthage could cause install to fail silently with cryptic `Module 'BleClientManager' not found` error message.
Now if carthage fails on darwin platform, `postinstall` fails as well.

Should solve #105 