### PR TITLE
Fix NPE in Device.java when using cancelConnection

### DIFF
--- a/android/src/main/java/com/polidea/reactnativeble/wrapper/Device.java
+++ b/android/src/main/java/com/polidea/reactnativeble/wrapper/Device.java
@@ -72,7 +72,11 @@ public class Device  {
         } else {
             result.putNull(Metadata.RSSI);
         }
-        result.putInt(Metadata.MTU, connection.getMtu());
+        if(connection != null) {
+            result.putInt(Metadata.MTU, connection.getMtu());
+        } else {
+            result.putNull(Metadata.MTU);
+        }
 
         // Advertisement data is not set
         result.putNull(Metadata.MANUFACTURER_DATA);


### PR DESCRIPTION
Previously a NPE would occur whenever cancelConnection was invoked on a device, due to the invocation at https://github.com/Polidea/react-native-ble-plx/blob/b2bb908601c704c090b2e0a50e120d9ed1bd8e92/android/src/main/java/com/polidea/reactnativeble/BleModule.java#L477