### PR TITLE
Updated android build tools so that it works with newest android studio

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.0'
         classpath 'org.codehaus.groovy:groovy-android-gradle-plugin:1.1.0'
     }
 }


### PR DESCRIPTION
Updated android build tools to 2.2.0 because 2.1.2 doesn't work with android studio >= 2.3. 
There is also newer version - 3.0.0 but it is compilant only with android sudio 3.0.

Android build tools affects only building of library and won't affect apps that are using this library.

