### PR TITLE
Fixed colissions in Characteristic and Service id generation.

### DIFF
--- a/android/src/main/java/com/polidea/reactnativeble/utils/IdGenerator.java
+++ b/android/src/main/java/com/polidea/reactnativeble/utils/IdGenerator.java
@@ -1,19 +1,17 @@
 package com.polidea.reactnativeble.utils;
 
-import android.util.Pair;
 import java.util.HashMap;
-import java.util.UUID;
 
 public class IdGenerator {
-    private static HashMap<Pair<UUID, Integer>, Integer> idMap = new HashMap<>();
+    private static HashMap<IdGeneratorKey, Integer> idMap = new HashMap<>();
     private static int nextKey = 0;
 
-    public static int getIdForKey(Pair<UUID, Integer> keyPair) {
-        Integer id = idMap.get(keyPair);
+    public static int getIdForKey(IdGeneratorKey idGeneratorKey) {
+        Integer id = idMap.get(idGeneratorKey);
         if (id != null) {
             return id;
         }
-        idMap.put(keyPair, ++nextKey);
+        idMap.put(idGeneratorKey, ++nextKey);
         return nextKey;
     }
 

--- a/android/src/main/java/com/polidea/reactnativeble/utils/IdGeneratorKey.java
+++ b/android/src/main/java/com/polidea/reactnativeble/utils/IdGeneratorKey.java
@@ -1,0 +1,42 @@
+package com.polidea.reactnativeble.utils;
+
+
+import com.polidea.rxandroidble.RxBleDevice;
+import java.util.UUID;
+
+public class IdGeneratorKey {
+
+    private final RxBleDevice bluetoothDevice;
+    private final UUID uuid;
+    private final int id;
+
+    public IdGeneratorKey(RxBleDevice bluetoothDevice, UUID uuid, int id) {
+        this.bluetoothDevice = bluetoothDevice;
+        this.uuid = uuid;
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof IdGeneratorKey)) {
+            return false;
+        }
+
+        IdGeneratorKey that = (IdGeneratorKey) o;
+
+        return id == that.id &&
+                bluetoothDevice.getMacAddress().equals(that.bluetoothDevice.getMacAddress()) &&
+                uuid.equals(that.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = bluetoothDevice.getMacAddress().hashCode();
+        result = 31 * result + uuid.hashCode();
+        result = 31 * result + id;
+        return result;
+    }
+}

--- a/android/src/main/java/com/polidea/reactnativeble/wrapper/Characteristic.java
+++ b/android/src/main/java/com/polidea/reactnativeble/wrapper/Characteristic.java
@@ -3,12 +3,12 @@ package com.polidea.reactnativeble.wrapper;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.support.annotation.NonNull;
-import android.util.Pair;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.polidea.reactnativeble.utils.Base64Converter;
 import com.polidea.reactnativeble.utils.IdGenerator;
+import com.polidea.reactnativeble.utils.IdGeneratorKey;
 import com.polidea.reactnativeble.utils.UUIDConverter;
 import com.polidea.rxandroidble.internal.RxBleLog;
 
@@ -40,7 +40,7 @@ public class Characteristic {
     public Characteristic(@NonNull Service service, @NonNull BluetoothGattCharacteristic characteristic) {
         this.service = service;
         this.characteristic = characteristic;
-        this.id = IdGenerator.getIdForKey(new Pair<>(characteristic.getUuid(), characteristic.getInstanceId()));
+        this.id = IdGenerator.getIdForKey(new IdGeneratorKey(service.getDevice().getNativeDevice(), characteristic.getUuid(), characteristic.getInstanceId()));
     }
 
     public int getId() {

--- a/android/src/main/java/com/polidea/reactnativeble/wrapper/Service.java
+++ b/android/src/main/java/com/polidea/reactnativeble/wrapper/Service.java
@@ -4,11 +4,11 @@ import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattService;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Pair;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.polidea.reactnativeble.utils.IdGenerator;
+import com.polidea.reactnativeble.utils.IdGeneratorKey;
 import com.polidea.reactnativeble.utils.UUIDConverter;
 
 import java.util.ArrayList;
@@ -31,7 +31,7 @@ public class Service {
     public Service(@NonNull Device device, @NonNull BluetoothGattService service) {
         this.device = device;
         this.service = service;
-        this.id = IdGenerator.getIdForKey(new Pair<>(service.getUuid(), service.getInstanceId()));
+        this.id = IdGenerator.getIdForKey(new IdGeneratorKey(device.getNativeDevice(), service.getUuid(), service.getInstanceId()));
     }
 
     public int getId() {


### PR DESCRIPTION
The collisions had place if multiple devices with the same characteristic/service uuids were connected at the same time due to `BluetoothGattCharacteristic.getInstanceId()` being unique only for characteristics having the same UUID in the scope of a single device. Fixed by adding mac address of the device to the id generation algorithm.