### PR TITLE
Added support for custom BLE error codes dictionary

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -897,6 +897,16 @@
               
                 
                 <li><a
+                  href='#bleerrorcodemessage'
+                  class="">
+                  BleErrorCodeMessage
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#bleatterrorcode'
                   class=" toggle-sibling">
                   BleATTErrorCode
@@ -1371,6 +1381,16 @@
               
                 
                 <li><a
+                  href='#bleerrorcodemessagemapping'
+                  class="">
+                  BleErrorCodeMessageMapping
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#blemanageroptions'
                   class=" toggle-sibling">
                   BleManagerOptions
@@ -1393,6 +1413,12 @@
                         href='#blemanageroptionsrestorestatefunction'
                         class='regular pre-open'>
                         #restoreStateFunction
+                      </a></li>
+                      
+                      <li><a
+                        href='#blemanageroptionserrorcodestomessagesmapping'
+                        class='regular pre-open'>
+                        #errorCodesToMessagesMapping
                       </a></li>
                       
                     </ul>
@@ -7164,7 +7190,7 @@ library. It contains additional properties which help to identify problems in
 platform independent way.</p>
 
 
-  <div class='pre p1 fill-light mt0'>new BleError(nativeBleError: (NativeBleError | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</div>
+  <div class='pre p1 fill-light mt0'>new BleError(nativeBleError: (NativeBleError | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), errorMessageMapping: <a href="#bleerrorcodemessagemapping">BleErrorCodeMessageMapping</a>)</div>
   
   
     <p>
@@ -7189,6 +7215,14 @@ platform independent way.</p>
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>nativeBleError</span> <code class='quiet'>((NativeBleError | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
+	    
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>errorMessageMapping</span> <code class='quiet'>(<a href="#bleerrorcodemessagemapping">BleErrorCodeMessageMapping</a>)</code>
 	    
           </div>
           
@@ -9237,6 +9271,53 @@ to cache them.</p>
     </div>
   
 </div>
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='bleerrorcodemessage'>
+      BleErrorCodeMessage
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Mapping of error codes to error messages</p>
+
+
+  <div class='pre p1 fill-light mt0'>BleErrorCodeMessage</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
 
   
 
@@ -12248,6 +12329,58 @@ received by <a href="#blemanager">BleManager</a></p>
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='bleerrorcodemessagemapping'>
+      BleErrorCodeMessageMapping
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Type of error code mapping table</p>
+
+
+  <div class='pre p1 fill-light mt0'>BleErrorCodeMessageMapping</div>
+  
+    <p>
+      Type:
+      {}
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='blemanageroptions'>
       BleManagerOptions
     </h3>
@@ -12284,6 +12417,12 @@ received by <a href="#blemanager">BleManager</a></p>
       
         <div class='space-bottom0'>
           <span class='code bold'>restoreStateFunction</span> <code class='quiet'>(function (restoredState: <a href="#blerestoredstate">BleRestoredState</a>?): void?)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>errorCodesToMessagesMapping</span> <code class='quiet'>(<a href="#bleerrorcodemessagemapping">BleErrorCodeMessageMapping</a>?)</code>
           
           
         </div>
@@ -12369,6 +12508,55 @@ connected peripherals.</p>
 
 
   <div class='pre p1 fill-light mt0'>restoreStateFunction</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='blemanageroptionserrorcodestomessagesmapping'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>errorCodesToMessagesMapping</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>Optional mapping of error codes to error messages. Uses <a href="#bleerrorcodemessage">BleErrorCodeMessage</a>
+by default.</p>
+<p>To override logging UUIDs or MAC adresses in error messages copy the original object
+and overwrite values of interest to you.</p>
+
+
+  <div class='pre p1 fill-light mt0'>errorCodesToMessagesMapping</div>
   
   
 

--- a/documentation.yml
+++ b/documentation.yml
@@ -17,7 +17,8 @@ toc:
     description: |
       Types and classes related to BLE errors.
   - BleError
-  - BleErrorCode 
+  - BleErrorCode
+  - BleErrorCodeMessage
   - BleATTErrorCode
   - BleAndroidErrorCode
   - BleIOSErrorCode
@@ -26,6 +27,7 @@ toc:
       All Flow aliases and Flow types used in this library.
   - LogLevel
   - State
+  - BleErrorCodeMessageMapping
   - BleManagerOptions
   - BleRestoredState
   - ScanOptions

--- a/src/BleError.js
+++ b/src/BleError.js
@@ -42,9 +42,9 @@ export class BleError extends Error {
    */
   reason: ?string
 
-  constructor(nativeBleError: NativeBleError | string) {
+  constructor(nativeBleError: NativeBleError | string, errorMessagesArray: Array<string>) {
     super()
-    this.message = BleErrorCodeMessage[BleErrorCode.UnknownError]
+    this.message = errorMessagesArray[BleErrorCode.UnknownError]
     if (typeof nativeBleError === 'string') {
       this.errorCode = BleErrorCode.UnknownError
       this.attErrorCode = null
@@ -52,7 +52,7 @@ export class BleError extends Error {
       this.androidErrorCode = null
       this.reason = nativeBleError
     } else {
-      const message = BleErrorCodeMessage[nativeBleError.errorCode]
+      const message = errorMessagesArray[nativeBleError.errorCode]
       if (message) {
         this.message = fillStringWithArguments(message, nativeBleError)
       }
@@ -66,13 +66,14 @@ export class BleError extends Error {
   }
 }
 
-export function parseBleError(errorMessage: string): BleError {
-  let bleError: BleError
+export function parseBleError(errorMessage: string, errorMessagesArray: Array<string>): BleError {
+	let bleError: BleError
+	const dictionary = errorMessagesArray ? errorMessagesArray : BleErrorCodeMessage
   try {
     const nativeBleError = JSON.parse(errorMessage)
-    bleError = new BleError(nativeBleError)
+    bleError = new BleError(nativeBleError, dictionary)
   } catch (parseError) {
-    bleError = new BleError(errorMessage)
+    bleError = new BleError(errorMessage, dictionary)
   }
   return bleError
 }

--- a/src/BleError.js
+++ b/src/BleError.js
@@ -1,5 +1,6 @@
 // @flow
 import { fillStringWithArguments } from './Utils'
+import type { BleErrorCodeMessageMapping } from './TypeDefinition'
 
 export interface NativeBleError {
   errorCode: $Values<typeof BleErrorCode>;
@@ -42,9 +43,9 @@ export class BleError extends Error {
    */
   reason: ?string
 
-  constructor(nativeBleError: NativeBleError | string, errorMessagesArray: Array<string>) {
+  constructor(nativeBleError: NativeBleError | string, errorMessageMapping: BleErrorCodeMessageMapping) {
     super()
-    this.message = errorMessagesArray[BleErrorCode.UnknownError]
+    this.message = errorMessageMapping[BleErrorCode.UnknownError]
     if (typeof nativeBleError === 'string') {
       this.errorCode = BleErrorCode.UnknownError
       this.attErrorCode = null
@@ -52,7 +53,7 @@ export class BleError extends Error {
       this.androidErrorCode = null
       this.reason = nativeBleError
     } else {
-      const message = errorMessagesArray[nativeBleError.errorCode]
+      const message = errorMessageMapping[nativeBleError.errorCode]
       if (message) {
         this.message = fillStringWithArguments(message, nativeBleError)
       }
@@ -62,18 +63,18 @@ export class BleError extends Error {
       this.androidErrorCode = nativeBleError.androidErrorCode
       this.reason = nativeBleError.reason
     }
-    this.name = "BleError"
+    this.name = 'BleError'
   }
 }
 
-export function parseBleError(errorMessage: string, errorMessagesArray: Array<string>): BleError {
-	let bleError: BleError
-	const dictionary = errorMessagesArray ? errorMessagesArray : BleErrorCodeMessage
+export function parseBleError(errorMessage: string, errorMessageMapping: BleErrorCodeMessageMapping): BleError {
+  let bleError: BleError
+  const errorMapping = errorMessageMapping ? errorMessageMapping : BleErrorCodeMessage
   try {
     const nativeBleError = JSON.parse(errorMessage)
-    bleError = new BleError(nativeBleError, dictionary)
+    bleError = new BleError(nativeBleError, errorMapping)
   } catch (parseError) {
-    bleError = new BleError(errorMessage, dictionary)
+    bleError = new BleError(errorMessage, errorMapping)
   }
   return bleError
 }
@@ -262,7 +263,11 @@ export const BleErrorCode = {
   LocationServicesDisabled: 601
 }
 
-export const BleErrorCodeMessage = {
+/**
+ * Mapping of error codes to error messages
+ * @name BleErrorCodeMessage
+ */
+export const BleErrorCodeMessage: BleErrorCodeMessageMapping = {
   // Implementation specific errors
   [BleErrorCode.UnknownError]: 'Unknown error occurred. This is probably a bug! Check reason property.',
   [BleErrorCode.BluetoothManagerDestroyed]: 'BleManager was destroyed',

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -66,7 +66,19 @@ export interface BleManagerOptions {
    * @memberof BleManagerOptions
    * @instance
    */
-  restoreStateFunction?: (restoredState: ?BleRestoredState) => void;
+	restoreStateFunction?: (restoredState: ?BleRestoredState) => void;
+	
+	/**
+	 * Optional mapping of error codes to error messages. Uses {@link BleErrorCodeMessage} 
+	 * by default.
+	 * 
+	 * To override logging UUIDs or MAC adresses in error messages copy the original object 
+	 * and overwrite values of interest to you.
+	 * 
+	 * @memberof BleManagerOptions
+	 * @instance 
+	 */
+	errorMessages?: Array<string>;
 }
 
 /**

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -2,6 +2,7 @@
 'use strict'
 
 import { Device } from './Device'
+import { BleErrorCode } from './BleError'
 
 /**
  * Bluetooth device id.
@@ -47,6 +48,11 @@ export interface Subscription {
 }
 
 /**
+ * Type of error code mapping table
+ */
+export type BleErrorCodeMessageMapping = { [$Values<typeof BleErrorCode>]: string }
+
+/**
  * Options which can be passed to when creating BLE Manager
  */
 export interface BleManagerOptions {
@@ -66,19 +72,19 @@ export interface BleManagerOptions {
    * @memberof BleManagerOptions
    * @instance
    */
-	restoreStateFunction?: (restoredState: ?BleRestoredState) => void;
-	
-	/**
-	 * Optional mapping of error codes to error messages. Uses {@link BleErrorCodeMessage} 
-	 * by default.
-	 * 
-	 * To override logging UUIDs or MAC adresses in error messages copy the original object 
-	 * and overwrite values of interest to you.
-	 * 
-	 * @memberof BleManagerOptions
-	 * @instance 
-	 */
-	errorMessages?: Array<string>;
+  restoreStateFunction?: (restoredState: ?BleRestoredState) => void;
+
+  /**
+   * Optional mapping of error codes to error messages. Uses {@link BleErrorCodeMessage}
+   * by default.
+   *
+   * To override logging UUIDs or MAC adresses in error messages copy the original object
+   * and overwrite values of interest to you.
+   *
+   * @memberof BleManagerOptions
+   * @instance
+   */
+  errorCodesToMessagesMapping?: BleErrorCodeMessageMapping;
 }
 
 /**


### PR DESCRIPTION
User can add optional array of strings containing messages to be carried
by errors. This way the developer can decide what should be inside an
error message (eg. when one wants to skip MAC address from the logs).