### PR TITLE
Fixes possible ConcurrentModificationException in Android BleModule

### DIFF
--- a/android/src/main/java/com/polidea/reactnativeble/utils/DisposableMap.java
+++ b/android/src/main/java/com/polidea/reactnativeble/utils/DisposableMap.java
@@ -10,14 +10,14 @@ public class DisposableMap {
 
     final private Map<String, Subscription> subscriptions = new HashMap<>();
 
-    public void replaceSubscription(String key, Subscription subscription) {
+    public synchronized void replaceSubscription(String key, Subscription subscription) {
         Subscription oldSubscription = subscriptions.put(key, subscription);
         if (oldSubscription != null && !oldSubscription.isUnsubscribed()) {
             oldSubscription.unsubscribe();
         }
     }
 
-    public boolean removeSubscription(String key) {
+    public synchronized boolean removeSubscription(String key) {
         Subscription subscription = subscriptions.remove(key);
         if (subscription == null) return false;
         if (!subscription.isUnsubscribed()) {
@@ -26,7 +26,7 @@ public class DisposableMap {
         return true;
     }
 
-    public void removeAllSubscriptions() {
+    public synchronized void removeAllSubscriptions() {
         Iterator<Map.Entry<String, Subscription>> it = subscriptions.entrySet().iterator();
         while (it.hasNext()) {
             Subscription subscription = it.next().getValue();


### PR DESCRIPTION
Fixes #352 

As an alternative there is possibility of using `ConcurrentHashMap` instead of just `HashMap`. The issue with the alternate approach is that it:
> [This class is fully interoperable with Hashtable in programs that rely on its thread safety but not on its synchronization details.](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html)

Which could potentially cause other hard to debug issues.