### PR TITLE
Workaround for when canSendWriteWithoutResponse returning false

### DIFF
--- a/ios/RxBluetoothKit/RxCBPeripheral.swift
+++ b/ios/RxBluetoothKit/RxCBPeripheral.swift
@@ -58,8 +58,8 @@ class RxCBPeripheral: RxPeripheralType {
     }
 
     var canSendWriteWithoutResponse: Bool {
-        // Although available since iOS 11.0, on version < iOS 11.2 canSendWriteWithoutResponse
-        // always returns false (on first try), take care of this by returning true for < iOS 11.2
+        // Although available since iOS 11.0, on versions < iOS 11.2 canSendWriteWithoutResponse will always
+        // return false (on first try). We work around this issue by always returning true for < iOS 11.2.
         // See: https://github.com/Polidea/react-native-ble-plx/issues/365
         if #available(iOS 11.2, *) {
             return peripheral.canSendWriteWithoutResponse

--- a/ios/RxBluetoothKit/RxCBPeripheral.swift
+++ b/ios/RxBluetoothKit/RxCBPeripheral.swift
@@ -58,7 +58,10 @@ class RxCBPeripheral: RxPeripheralType {
     }
 
     var canSendWriteWithoutResponse: Bool {
-        if #available(iOS 11.0, *) {
+        // Although available since iOS 11.0, on version < iOS 11.2 canSendWriteWithoutResponse
+        // always returns false (on first try), take care of this by returning true for < iOS 11.2
+        // See: https://github.com/Polidea/react-native-ble-plx/issues/365
+        if #available(iOS 11.2, *) {
             return peripheral.canSendWriteWithoutResponse
         } else {
             return true


### PR DESCRIPTION
On iOS <11.2 `canSendWriteWithoutResponse` will return `false` on first attempt, see:
https://forums.developer.apple.com/thread/80376

Linked issue: https://github.com/Polidea/react-native-ble-plx/issues/365