### PR TITLE
Remove destroying of client upon catalystInstanceDestroy.

### DIFF
--- a/android/src/main/java/com/polidea/reactnativeble/BleClientManager.java
+++ b/android/src/main/java/com/polidea/reactnativeble/BleClientManager.java
@@ -99,12 +99,6 @@ public class BleClientManager extends ReactContextBaseJavaModule {
         bleAdapter.destroyClient();
     }
 
-    @Override
-    public void onCatalystInstanceDestroy() {
-        super.onCatalystInstanceDestroy();
-        destroyClient();
-    }
-
     // Mark: Common --------------------------------------------------------------------------------
 
     @ReactMethod


### PR DESCRIPTION
I would like to challenge why the bleClient is destroyed onCatalystInstanceDestroy?

For us, it breaks being connected and refreshing our app in development mode. And we are also having bug reports in Sentry related to this. I think it relates with https://github.com/Polidea/react-native-ble-plx/issues/405.