### PR TITLE
Configure npm version to use current tag convention

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix=""


### PR DESCRIPTION
npm tag convention — https://docs.npmjs.com/cli/v6/using-npm/config/#tag-version-prefix