### PR TITLE
fix(android): prevent crash when Promise.reject is called with null error code

### DIFF
--- a/android/src/main/java/com/bleplx/utils/SafePromise.java
+++ b/android/src/main/java/com/bleplx/utils/SafePromise.java
@@ -20,28 +20,35 @@ public class SafePromise {
     }
   }
 
-  public void reject(String code, String message) {
+  // Safe reject: ensures code is never null
+  public void reject(@Nullable String code, @Nullable String message) {
     if (isFinished.compareAndSet(false, true)) {
-      promise.reject(code, message);
+      String safeCode = code != null ? code : "UNKNOWN_ERROR";
+      String safeMessage = message != null ? message : "No message provided";
+      promise.reject(safeCode, safeMessage);
     }
   }
 
-  public void reject(String code, Throwable e) {
+  public void reject(@Nullable String code, Throwable e) {
     if (isFinished.compareAndSet(false, true)) {
-      promise.reject(code, e);
+      String safeCode = code != null ? code : "UNKNOWN_ERROR";
+      promise.reject(safeCode, e);
     }
   }
 
-  public void reject(String code, String message, Throwable e) {
+  public void reject(@Nullable String code, @Nullable String message, Throwable e) {
     if (isFinished.compareAndSet(false, true)) {
-      promise.reject(code, message, e);
+      String safeCode = code != null ? code : "UNKNOWN_ERROR";
+      String safeMessage = message != null ? message : "No message provided";
+      promise.reject(safeCode, safeMessage, e);
     }
   }
 
   @Deprecated
-  public void reject(String message) {
+  public void reject(@Nullable String message) {
     if (isFinished.compareAndSet(false, true)) {
-      promise.reject(message);
+      String safeMessage = message != null ? message : "No message provided";
+      promise.reject(safeMessage);
     }
   }
 


### PR DESCRIPTION
# Fix: Prevent Android crash when BLE disconnect error has null error code

## Summary

This PR fixes a fatal Android crash that occurs when `Promise.reject()` is called with a null error code during BLE disconnect flows.

On Android, `RxAndroidBle` emits a `BleDisconnectedException` for both expected and unexpected disconnects. In some cases, the propagated error does not contain a non-null error code, which violates React Native's `Promise.reject` contract and results in a `NullPointerException`.

This change ensures a safe fallback error code is always provided.

---

## Problem

During normal BLE lifecycle events (navigation cleanup, explicit disconnect, device power loss), the app may crash with:
```
java.lang.NullPointerException:
Parameter specified as non-null is null:
method com.facebook.react.bridge.PromiseImpl.reject, parameter code
```

This crash occurs even when the disconnect is expected and properly handled in JavaScript.

---

## Root Cause

`SafePromise.reject(...)` forwards a nullable `code` value into `Promise.reject(code, ...)`.

React Native requires `code` to be non-null, which causes a runtime crash.

---

## Solution

Provide a defensive fallback error code when `code` is null before calling `Promise.reject`.

**Example:**
```java
String safeCode = code != null ? code : "UNKNOWN_ERROR";
promise.reject(safeCode, message, throwable);
```

---

## Impact

- Prevents Android crashes during normal BLE disconnect flows
- No behavior change for JS consumers
- Improves stability in real-world BLE lifecycle scenarios