### PR TITLE
fix: prevent unhandled promise rejection when fetching state

### DIFF
--- a/src/BleManager.js
+++ b/src/BleManager.js
@@ -316,11 +316,16 @@ export class BleManager {
 
     if (emitCurrentState) {
       var cancelled = false
-      this._callPromise(this.state()).then(currentState => {
-        if (!cancelled) {
-          listener(currentState)
+      this._callPromise(this.state()).then(
+        currentState => {
+          if (!cancelled) {
+            listener(currentState)
+          }
+        },
+        () => {
+          // Prevent unhandled promise rejection for internal state fetch.
         }
-      })
+      )
 
       wrappedSubscription = {
         remove: () => {


### PR DESCRIPTION
Adds a rejection handler to the internal state fetch when a listener is attached to avoid potential unhandled promise rejections.

Fixes [#1315](https://github.com/dotintent/react-native-ble-plx/issues/1307)