### PR TITLE
fix: keep longest manufacturer data when scan record has multiple 0xFF AD structures

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,6 +91,8 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation 'io.reactivex.rxjava2:rxjava:2.2.17'
   implementation "com.polidea.rxandroidble2:rxandroidble:1.17.2"
+
+  testImplementation "junit:junit:4.13.2"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/com/bleplx/adapter/AdvertisementData.java
+++ b/android/src/main/java/com/bleplx/adapter/AdvertisementData.java
@@ -199,6 +199,15 @@ public class AdvertisementData {
 
   private static void parseManufacturerData(AdvertisementData advData, int adLength, ByteBuffer data) {
     if (adLength < 2) return;
+    // A merged scan record can carry more than one manufacturer-specific AD
+    // structure (0xFF), e.g. one from ADV_IND and another from SCAN_RSP. The
+    // previous behaviour kept whichever structure appeared last, so a short
+    // placeholder could replace the real payload. Keep the longest structure
+    // instead, matching what iOS exposes via CoreBluetooth's merged
+    // advertisement data.
+    if (advData.manufacturerData != null && advData.manufacturerData.length >= adLength) {
+      return;
+    }
     advData.manufacturerData = new byte[adLength];
     data.get(advData.manufacturerData, 0, adLength);
   }

--- a/android/src/test/java/com/bleplx/adapter/AdvertisementDataTest.java
+++ b/android/src/test/java/com/bleplx/adapter/AdvertisementDataTest.java
@@ -1,0 +1,130 @@
+package com.bleplx.adapter;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class AdvertisementDataTest {
+
+  // --- helpers -------------------------------------------------------------
+
+  private static byte[] mfgStructure(byte... payload) {
+    byte[] structure = new byte[payload.length + 2];
+    structure[0] = (byte) (payload.length + 1); // AD length includes the type byte
+    structure[1] = (byte) 0xFF;                 // manufacturer specific data
+    System.arraycopy(payload, 0, structure, 2, payload.length);
+    return structure;
+  }
+
+  private static byte[] concat(byte[]... parts) {
+    int length = 0;
+    for (byte[] part : parts) length += part.length;
+    byte[] record = new byte[length];
+    int offset = 0;
+    for (byte[] part : parts) {
+      System.arraycopy(part, 0, record, offset, part.length);
+      offset += part.length;
+    }
+    return record;
+  }
+
+  private static final byte[] LOCAL_NAME_TEST = {0x05, 0x09, 'T', 'e', 's', 't'};
+
+  private static final byte[] LONG_PAYLOAD = {0x64, 0x4E, 0x01, 0x02};
+  private static final byte[] SHORT_PAYLOAD = {0x46, 0x46};
+
+  // --- single structure: behaviour unchanged --------------------------------
+
+  @Test
+  public void parsesSingleManufacturerDataStructure() {
+    AdvertisementData advData =
+      AdvertisementData.parseScanResponseData(mfgStructure(LONG_PAYLOAD));
+
+    assertArrayEquals(LONG_PAYLOAD, advData.getManufacturerData());
+  }
+
+  @Test
+  public void ignoresManufacturerDataShorterThanCompanyId() {
+    AdvertisementData advData =
+      AdvertisementData.parseScanResponseData(mfgStructure((byte) 0x64));
+
+    assertNull(advData.getManufacturerData());
+  }
+
+  // --- multiple structures: the longest one wins ----------------------------
+
+  @Test
+  public void keepsLongerManufacturerDataWhenShorterFollows() {
+    // e.g. real payload advertised in ADV_IND, placeholder in SCAN_RSP
+    byte[] record = concat(mfgStructure(LONG_PAYLOAD), mfgStructure(SHORT_PAYLOAD));
+
+    AdvertisementData advData = AdvertisementData.parseScanResponseData(record);
+
+    assertArrayEquals(LONG_PAYLOAD, advData.getManufacturerData());
+  }
+
+  @Test
+  public void keepsLongerManufacturerDataWhenLongerFollows() {
+    // e.g. placeholder advertised in ADV_IND, real payload in SCAN_RSP
+    byte[] record = concat(mfgStructure(SHORT_PAYLOAD), mfgStructure(LONG_PAYLOAD));
+
+    AdvertisementData advData = AdvertisementData.parseScanResponseData(record);
+
+    assertArrayEquals(LONG_PAYLOAD, advData.getManufacturerData());
+  }
+
+  @Test
+  public void keepsFirstManufacturerDataOnEqualLength() {
+    byte[] first = {0x01, 0x02, 0x03};
+    byte[] second = {0x04, 0x05, 0x06};
+    byte[] record = concat(mfgStructure(first), mfgStructure(second));
+
+    AdvertisementData advData = AdvertisementData.parseScanResponseData(record);
+
+    assertArrayEquals(first, advData.getManufacturerData());
+  }
+
+  @Test
+  public void continuesParsingSubsequentStructuresAfterKeepingExisting() {
+    // a kept-as-is (ignored) shorter structure must not desynchronize the
+    // cursor: the local name that follows it still has to parse correctly
+    byte[] record =
+      concat(mfgStructure(LONG_PAYLOAD), mfgStructure(SHORT_PAYLOAD), LOCAL_NAME_TEST);
+
+    AdvertisementData advData = AdvertisementData.parseScanResponseData(record);
+
+    assertArrayEquals(LONG_PAYLOAD, advData.getManufacturerData());
+    assertEquals("Test", advData.getLocalName());
+  }
+
+  // --- real-world capture ----------------------------------------------------
+
+  @Test
+  public void parsesRealWorldMergedScanRecord() {
+    // Merged scan record captured from a peripheral that advertises its real
+    // 25-byte identity in one packet and a 12-byte "FFFFFFFFFFFF" placeholder
+    // in the other (see PR description). Previously the placeholder won.
+    byte[] record = {
+      0x02, 0x01, 0x06, 0x1A, (byte) 0xFF, 0x64, 0x4E, 0x43,
+      0x50, 0x64, 0x53, 0x67, 0x6D, 0x52, 0x50, 0x35,
+      0x30, 0x31, 0x30, 0x31, 0x30, 0x35, 0x39, 0x30,
+      0x30, 0x31, 0x31, 0x38, 0x39, 0x01, 0x0D, (byte) 0xFF,
+      0x46, 0x46, 0x46, 0x46, 0x46, 0x46, 0x46, 0x46,
+      0x46, 0x46, 0x46, 0x46, 0x0D, 0x09, 0x41, 0x49,
+      0x20, 0x4E, 0x6F, 0x74, 0x65, 0x2D, 0x34, 0x45,
+      0x36, 0x33, 0x00, 0x00, 0x00, 0x00
+    };
+    byte[] realPayload = {
+      0x64, 0x4E, 0x43, 0x50, 0x64, 0x53, 0x67, 0x6D, 0x52, 0x50, 0x35, 0x30,
+      0x31, 0x30, 0x31, 0x30, 0x35, 0x39, 0x30, 0x30, 0x31, 0x31, 0x38, 0x39,
+      0x01
+    };
+
+    AdvertisementData advData = AdvertisementData.parseScanResponseData(record);
+
+    assertArrayEquals(realPayload, advData.getManufacturerData());
+    assertEquals("AI Note-4E63", advData.getLocalName());
+  }
+}


### PR DESCRIPTION
## Prerequisites

- [x] I am working on the latest version of the library (branched from `master`, also reproduced on v3.5.1).
- [x] I tested the change locally on Android hardware — 7 physical peripherals verified with the fix; a representative before/after capture from one of them is decoded below. The change is in Android-only parsing code (`AdvertisementData.java`); the iOS path (CoreBluetooth's merged advertisement data) is untouched.
- [x] I ran `npm test` and `npm run lint`: results are identical on unmodified `master` and on this branch (the change is Java-only). In my environment some jest suites fail at setup on both branches equally (a local `NativeEventEmitter`/Node-version issue; every test that runs passes on both), and the final `tsc --noEmit` lint step needs the example app's dependencies on both — flow, eslint and documentation lint pass unchanged. CI's pinned environments should come back green.
- [x] Local regression tests: added `android/src/test/java/com/bleplx/adapter/AdvertisementDataTest.java` (plus a `testImplementation "junit:junit:4.13.2"` line — test-only, nothing shipped to consumers). 7 tests cover single-structure parsing, the sub-2-byte guard, both orderings of duplicate `0xFF` structures, the equal-length tie-break, cursor integrity after a kept-as-is structure, and the real-world captured record below. **4 of the 7 fail against the previous last-wins behaviour; all 7 pass with the fix.** The class only depends on `java.*`, so they run as plain JVM unit tests.

## Bug description

On Android, when a merged scan record contains **more than one manufacturer-specific AD structure (`0xFF`)** — typically one in ADV_IND and another in SCAN_RSP — `Device.manufacturerData` only ever exposes the **last** structure in the byte stream. Whatever came before it is silently lost.

Cause: `parseScanResponseData` walks every AD structure of the merged record and `parseManufacturerData` unconditionally overwrites `advData.manufacturerData` on each `0xFF` it meets:

```java
private static void parseManufacturerData(AdvertisementData advData, int adLength, ByteBuffer data) {
  if (adLength < 2) return;
  advData.manufacturerData = new byte[adLength];   // <- last one always wins
  data.get(advData.manufacturerData, 0, adLength);
}
```

iOS is unaffected: CoreBluetooth hands over the merged `CBAdvertisementDataManufacturerDataKey`, so the same peripheral yields the real payload on iOS and a placeholder on Android — a platform behavior divergence.

This has been reported repeatedly over the years but never fixed at the parse layer: #483 (2019, byte-level analysis, closed by stale bot), #556 (reopen attempt), #949 (filed 2022, closed in 2023 by adding the `rawScanRecord` escape hatch in #1134 rather than fixing the merge), #970, and most recently #1306 (closed 2026 with the maintainer confirming the library exposes no ADV/SCAN_RSP distinction).

### Real-world reproduction (captured from production hardware)

Our peripheral (an audio recorder pen) advertises a 12-byte placeholder in one packet and the real 25-byte identity (which contains the device serial number) in the other. Raw scan record captured via `rawScanRecord` on Android (base64 `AgEGGv9kTkNQZFNnbVJQNTAxMDEwNTkwMDExODkBDf9GRkZGRkZGRkZGRkYNCUFJIE5vdGUtNEU2MwAAAAA=`), decoded:

| # | AD structure | len | data (ASCII) | meaning |
|---|---|---|---|---|
| 0 | Flags `0x01` | 1 | `0x06` | |
| 1 | **Manufacturer `0xFF`** | **25** | `dNCPdSgmRP50101059001189·` | **real payload** (contains serial) |
| 2 | **Manufacturer `0xFF`** | **12** | `FFFFFFFFFFFF` | placeholder |
| 3 | Complete Local Name `0x09` | 12 | `AI Note-4E63` | |

- `device.manufacturerData` (before this fix): `RkZGRkZGRkZGRkZG` = `"FFFFFFFFFFFF"` — the 12-byte placeholder, structure #1 is lost.
- Same device on iOS: the real payload is present in `manufacturerData` (our serial parsing works there unmodified).
- `device.manufacturerData` (after this fix): `ZE5DUGRTZ21SUDUwMTAxMDU5MDAxMTg5AQ==` — the real payload, restoring parity with iOS.

Verified on 7 physical devices: with the fix, every one of them exposes the real manufacturer data through the normal `manufacturerData` field instead of requiring the `rawScanRecord` workaround.

## Details

### The fix

Keep the **longest** manufacturer-data structure instead of the last one:

```java
if (advData.manufacturerData != null && advData.manufacturerData.length >= adLength) {
  return;
}
```

- **Cursor safety**: the early return cannot desynchronize parsing — `parseScanResponseData` advances `rawData.position()` itself (line 84) and passes each parser an independent `slice()`, so whether the callee consumes 0 or `adLength` bytes is irrelevant. `parseLocalName` already takes the same consume-nothing path when it ignores a shortened name (`0x08`) after a name has been set.
- **Scope**: nothing else in the library depends on the last-wins semantics — `getManufacturerData()` is only consumed by `ScanResultToJsObjectConverter` (base64 pass-through to JS).
- **Behavioral note**: for two structures of *equal* length the previous code kept the last, this change keeps the first. For the motivating case (placeholder vs. real payload) lengths always differ.

### Alternatives considered

1. **First-wins** — would fix our device but breaks peripherals that put the placeholder first; ordering of ADV_IND vs SCAN_RSP inside `ScanRecord.getBytes()` is not something to rely on either way.
2. **Concatenating all `0xFF` structures** — matches what some stacks do for *same-company-ID fragments*, but blindly concatenating distinct structures corrupts payloads of devices that broadcast genuinely different data per packet.
3. **Exposing all manufacturer-data structures** (list, or map keyed by company ID — note the BLE spec explicitly allows multiple structures with *different* company IDs) — the most complete fix, but an API addition rather than a bug fix. I'd be happy to follow up with that if you're interested; this PR deliberately stays minimal and non-breaking.

Keep-longest is the smallest change that restores iOS/Android parity for the common real-world pattern (short placeholder + full payload) without any API change.

### Standalone reproduction harness

`AdvertisementData` only depends on `java.*`, so the fix can be verified without an emulator:

```java
// two 0xFF structures: 4-byte payload first, 2-byte placeholder second
byte[] record = {
  0x05, (byte) 0xFF, 0x64, 0x4E, 0x01, 0x02,   // mfg: 64 4E 01 02 (real)
  0x03, (byte) 0xFF, 0x46, 0x46,               // mfg: 46 46 (placeholder)
  0x05, 0x09, 'T', 'e', 's', 't'               // local name: "Test"
};
AdvertisementData adv = AdvertisementData.parseScanResponseData(record);
// before: manufacturerData == [0x46, 0x46]  (placeholder wins)
// after:  manufacturerData == [0x64, 0x4E, 0x01, 0x02], localName == "Test"
```

